### PR TITLE
Handle invalid GeoTIFF responses

### DIFF
--- a/src/utils/geotiff.ts
+++ b/src/utils/geotiff.ts
@@ -1,0 +1,103 @@
+const textDecoder = new TextDecoder();
+
+function normaliseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function decodeSnippet(buffer: ArrayBuffer, maxLength = 2048): string {
+  const length = Math.min(buffer.byteLength, maxLength);
+  if (length === 0) {
+    return '';
+  }
+  const view = new Uint8Array(buffer, 0, length);
+  return textDecoder.decode(view);
+}
+
+function extractStructuredMessage(text: string): string | null {
+  const patterns = [
+    /<ows:ExceptionText>([\s\S]*?)<\/ows:ExceptionText>/i,
+    /<ExceptionText>([\s\S]*?)<\/ExceptionText>/i,
+    /<ServiceException(?:Text)?>([\s\S]*?)<\/ServiceException(?:Text)?>/i,
+    /"message"\s*:\s*"([^"]+)"/i
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (match && match[1]) {
+      return normaliseWhitespace(match[1]);
+    }
+  }
+
+  return null;
+}
+
+function contentLooksTextual(contentType: string | null, firstByte: number | undefined): boolean {
+  if (contentType) {
+    const lowered = contentType.toLowerCase();
+    if (lowered.includes('xml') || lowered.includes('json') || lowered.includes('html') || lowered.includes('text')) {
+      return true;
+    }
+  }
+
+  if (firstByte === 60 /* < */ || firstByte === 123 /* { */) {
+    return true;
+  }
+
+  return false;
+}
+
+export function ensureGeoTiffResponse(options: {
+  source: string;
+  response: Response;
+  buffer: ArrayBuffer;
+  coverageId?: string;
+}): void {
+  const { source, response, buffer, coverageId } = options;
+
+  if (buffer.byteLength < 4) {
+    const coverageSuffix = coverageId ? ` coverage "${coverageId}"` : '';
+    throw new Error(`${source}${coverageSuffix} returned an empty response.`);
+  }
+
+  const header = new Uint8Array(buffer, 0, 2);
+  const byte0 = header[0];
+  const byte1 = header[1];
+  const isLittleEndianTiff = byte0 === 0x49 && byte1 === 0x49; // 'II'
+  const isBigEndianTiff = byte0 === 0x4d && byte1 === 0x4d; // 'MM'
+
+  if (isLittleEndianTiff || isBigEndianTiff) {
+    return;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentLooksTextual(contentType, byte0)) {
+    const coverageSuffix = coverageId ? ` coverage "${coverageId}"` : '';
+    throw new Error(
+      `${source}${coverageSuffix} returned unexpected binary data (missing TIFF byte-order marker).`
+    );
+  }
+
+  const snippet = decodeSnippet(buffer);
+  const structuredMessage = extractStructuredMessage(snippet);
+  const fallback = normaliseWhitespace(snippet).slice(0, 280);
+  const detail = structuredMessage ?? fallback;
+
+  const coverageSuffix = coverageId ? ` coverage "${coverageId}"` : '';
+  const messageSuffix = detail ? `: ${detail}` : '.';
+  throw new Error(`${source}${coverageSuffix} request failed${messageSuffix}`);
+}
+
+export async function wrapGeoTiffDecode<T>(options: {
+  source: string;
+  coverageId?: string;
+  fn: () => Promise<T> | T;
+}): Promise<T> {
+  const { source, coverageId, fn } = options;
+  try {
+    return await fn();
+  } catch (error) {
+    const description = coverageId ? `${source} coverage "${coverageId}"` : source;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${description} could not be decoded: ${message}`);
+  }
+}

--- a/tests/geotiff.test.ts
+++ b/tests/geotiff.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { ensureGeoTiffResponse, wrapGeoTiffDecode } from '../src/utils/geotiff';
+
+describe('ensureGeoTiffResponse', () => {
+  it('accepts buffers with TIFF byte order markers', () => {
+    const buffer = new Uint8Array([0x49, 0x49, 0x2a, 0x00]).buffer;
+    const response = new Response(new Uint8Array(), {
+      headers: { 'content-type': 'image/tiff' }
+    });
+
+    expect(() =>
+      ensureGeoTiffResponse({
+        source: 'Test',
+        response,
+        buffer
+      })
+    ).not.toThrow();
+  });
+
+  it('throws a helpful error when an XML exception is returned', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows">
+  <ows:Exception>
+    <ows:ExceptionText>Request is invalid</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>`;
+    const encoded = new TextEncoder().encode(xml);
+    const buffer = encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength);
+    const response = new Response(xml, {
+      headers: { 'content-type': 'application/xml' }
+    });
+
+    expect(() =>
+      ensureGeoTiffResponse({
+        source: 'SoilGrids',
+        response,
+        buffer,
+        coverageId: 'phh2o_0-5cm_mean'
+      })
+    ).toThrowError(/SoilGrids coverage "phh2o_0-5cm_mean" request failed: Request is invalid/);
+  });
+});
+
+describe('wrapGeoTiffDecode', () => {
+  it('re-throws decoding errors with context', async () => {
+    await expect(
+      wrapGeoTiffDecode({
+        source: 'WorldCover',
+        coverageId: 'urn:test',
+        fn: async () => {
+          throw new Error('boom');
+        }
+      })
+    ).rejects.toThrowError('WorldCover coverage "urn:test" could not be decoded: boom');
+  });
+});


### PR DESCRIPTION
## Summary
- validate SoilGrids and WorldCover downloads before handing them to the GeoTIFF decoder and wrap failures with clearer context
- add a shared utility that extracts messages from WCS exception payloads and normalises GeoTIFF decode errors
- cover the new behaviour with unit tests

## Testing
- npx vitest run --environment node

------
https://chatgpt.com/codex/tasks/task_e_68cedf2f23b48321a4a4265aff050c9e