### PR TITLE
Darken woodland overlay

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -269,11 +269,12 @@ function drawSuitability(result: SuitabilityWorkerOutput) {
   for (let idx = 0; idx < result.categories.length; idx += 1) {
     const category = result.categories[idx];
     const baseIndex = idx * 4;
+    const isWoodland = result.woodlandMask[idx] === 1;
     let color: [number, number, number, number];
     if (category === 2) {
       color = [31, 191, 104, 170];
     } else if (category === 1) {
-      color = [255, 183, 77, 200];
+      color = isWoodland ? [18, 92, 43, 200] : [255, 183, 77, 200];
     } else {
       color = [255, 90, 95, 210];
     }

--- a/src/scoring/landcover.ts
+++ b/src/scoring/landcover.ts
@@ -7,7 +7,7 @@ export const enum LandClass {
 const IDEAL_CODES = new Set([20, 30, 100]);
 const CAUTION_CODES = new Set([90, 95]);
 const AVOID_CODES = new Set([40, 50, 60, 70, 80]);
-const WOODLAND_CODE = 10;
+export const WOODLAND_CODE = 10;
 
 export function deriveLandCoverClasses(codes: Uint8Array, width: number, height: number): Uint8Array {
   const classes = new Uint8Array(width * height);

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,4 +51,5 @@ export interface SuitabilityWorkerInput {
 export interface SuitabilityWorkerOutput extends SuitabilityResult {
   bbox: BoundingBox;
   requestId: number;
+  woodlandMask: Uint8Array;
 }


### PR DESCRIPTION
## Summary
- export the woodland cover code and include a woodland mask in worker results
- render woodland caution cells with a darker green so they no longer match ideal areas

## Testing
- npm run test -- --environment=node

------
https://chatgpt.com/codex/tasks/task_e_68cee3788b5883219e90032d543fac8a