### PR TITLE
Increase map zoom capability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,7 @@ const poorCountEl = document.getElementById('poor-count');
 const map = L.map('map', {
   preferCanvas: true,
   minZoom: 5,
-  maxZoom: 13,
+  maxZoom: 18,
   zoomControl: true,
   attributionControl: true
 }).setView([54.5, -2.5], 6);


### PR DESCRIPTION
## Summary
- raise the Leaflet map's maximum zoom level so the basemap and overlays can be inspected in greater detail

## Testing
- npm test -- --environment node

------
https://chatgpt.com/codex/tasks/task_e_68cee8f1a3088321aede69e71b604457