### PR TITLE
Handle zipped GeoTIFF responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shroommap",
       "version": "1.0.0",
       "dependencies": {
+        "fflate": "^0.8.2",
         "geotiff": "^2.1.3",
         "leaflet": "^1.9.4"
       },
@@ -1312,6 +1313,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "fflate": "^0.8.2",
     "geotiff": "^2.1.3",
     "leaflet": "^1.9.4"
   },

--- a/src/data/soilgrids.ts
+++ b/src/data/soilgrids.ts
@@ -10,7 +10,7 @@ import {
 import { InFlightMap, TimedCache } from './cache';
 import type { SoilGrid, SoilProperty } from '../types';
 import { mockSoilGrid } from './mock/soilgrids';
-import { ensureGeoTiffResponse, wrapGeoTiffDecode } from '../utils/geotiff';
+import { ensureGeoTiffResponse, extractGeoTiffBuffer, wrapGeoTiffDecode } from '../utils/geotiff';
 
 const COVERAGE_IDS: Record<SoilProperty, string> = {
   orcdrc: `orcdrc_${DEFAULT_DEPTH}_mean`,
@@ -132,7 +132,8 @@ export class SoilGridsClient {
 
         const url = `${SOILGRIDS_WCS_BASE}&${params.toString()}`;
         const response = await fetchWithBackoff(url, signal);
-        const arrayBuffer = await response.arrayBuffer();
+        const responseBuffer = await response.arrayBuffer();
+        const arrayBuffer = extractGeoTiffBuffer(responseBuffer);
         ensureGeoTiffResponse({
           source: 'SoilGrids',
           response,

--- a/src/data/worldcover.ts
+++ b/src/data/worldcover.ts
@@ -10,7 +10,7 @@ import {
 import { InFlightMap, TimedCache } from './cache';
 import type { LandCoverGrid } from '../types';
 import { mockWorldCover } from './mock/worldcover';
-import { ensureGeoTiffResponse, wrapGeoTiffDecode } from '../utils/geotiff';
+import { ensureGeoTiffResponse, extractGeoTiffBuffer, wrapGeoTiffDecode } from '../utils/geotiff';
 
 const CACHE_TTL_MS = 1000 * 60 * 30;
 const COVERAGE_ID = 'urn:cgls:worldcover:v200:2021';
@@ -103,7 +103,8 @@ export class WorldCoverClient {
 
     const url = `${WORLDCOVER_WCS_BASE}?${params.toString()}`;
     const response = await fetchWithBackoff(url, signal);
-    const arrayBuffer = await response.arrayBuffer();
+    const responseBuffer = await response.arrayBuffer();
+    const arrayBuffer = extractGeoTiffBuffer(responseBuffer);
     ensureGeoTiffResponse({
       source: 'WorldCover',
       response,

--- a/tests/geotiff.test.ts
+++ b/tests/geotiff.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, it } from 'vitest';
 
-import { ensureGeoTiffResponse, wrapGeoTiffDecode } from '../src/utils/geotiff';
+import { zipSync } from 'fflate';
+
+import { ensureGeoTiffResponse, extractGeoTiffBuffer, wrapGeoTiffDecode } from '../src/utils/geotiff';
+
+function toArrayBuffer(view: Uint8Array): ArrayBuffer {
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+}
+
+describe('extractGeoTiffBuffer', () => {
+  it('returns the original buffer for plain GeoTIFF data', () => {
+    const buffer = new Uint8Array([0x49, 0x49, 0x2a, 0x00]).buffer;
+    expect(extractGeoTiffBuffer(buffer)).toBe(buffer);
+  });
+
+  it('extracts the first GeoTIFF entry from a ZIP archive', () => {
+    const tifData = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00]);
+    const archive = zipSync({
+      'meta.txt': new Uint8Array([1, 2, 3]),
+      'tile.tif': tifData
+    });
+
+    const extracted = extractGeoTiffBuffer(toArrayBuffer(archive));
+    expect(new Uint8Array(extracted)).toEqual(tifData);
+  });
+
+  it('falls back to the first file when no GeoTIFF is present', () => {
+    const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const archive = zipSync({
+      'readme.txt': payload
+    });
+
+    const extracted = extractGeoTiffBuffer(toArrayBuffer(archive));
+    expect(new Uint8Array(extracted)).toEqual(payload);
+  });
+});
 
 describe('ensureGeoTiffResponse', () => {
   it('accepts buffers with TIFF byte order markers', () => {


### PR DESCRIPTION
## Summary
- extract GeoTIFF assets from zipped WCS responses before decoding SoilGrids and WorldCover rasters
- add a reusable archive helper with unit tests and depend on fflate for ZIP handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1009dcc883218406b925f9d99cb1