### PR TITLE
Clarify live data fallback status

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -91,6 +91,11 @@ body,
   color: var(--text-muted);
 }
 
+.status-note[data-variant='fallback'],
+.status-note[data-variant='mock'] {
+  color: #ffb74d;
+}
+
 .layer-toggle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show a fallback mode message when live map layers are unavailable
- update the mode indicator styles so synthetic data is highlighted

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfe6ea8c8483219a24d9a5389fbbce